### PR TITLE
Update Template #1

### DIFF
--- a/line-following-robot/javascript/README.md
+++ b/line-following-robot/javascript/README.md
@@ -2,18 +2,16 @@
 
 ## Introduction
 
-This line following robot application is part of a series of how-to Internet of Things (IoT) code sample exercises using the Intel® IoT Developer Kit, Intel® Edison board, Intel® IoT Gateway, cloud platforms, APIs, and other technologies.
+This line following robot application is part of a series of how-to Internet of Things (IoT) code sample exercises using the Intel® IoT Developer Kit and a compatible Intel® IoT Platform, cloud platforms, APIs, and other technologies.
 
 From this exercise, developers will learn how to:<br>
-- Connect the Intel® Edison board or Intel® IoT Gateway, computing platforms designed for prototyping and producing IoT and wearable computing products.<br>
-- Interface with the Intel® Edison board or Arduino 101\* (branded Genuino 101\* outside the U.S.) board IO and sensor repository using MRAA and UPM from the Intel® IoT Developer Kit, a complete hardware and software solution to help developers explore the IoT and implement innovative projects.<br>
-- Run this code sample in Intel® XDK IoT Edition, an IDE for creating applications that interact with sensors and actuators, enabling a quick start for developing software for the Intel® Edison board or Intel® IoT Gateway.<br>
+- Interface with and sensors using MRAA and UPM from the Intel® IoT Developer Kit, a complete hardware and software solution to help developers explore the IoT and implement innovative projects.<br>
 - Store line detection data using Azure Redis Cache\* from Microsoft Azure\*, Redis Store\* from IBM Bluemix\*, or Elasticache\* using Redis\* from Amazon Web Services (AWS)\*, different cloud services for connecting IoT solutions including data analysis, machine learning, and a variety of productivity tools to simplify the process of connecting your sensors to the cloud and getting your IoT project up and running quickly.
 - Connect to a server using IoT Hub from Microsoft Azure\*, IoT from IBM Bluemix\*, IoT from Amazon Web Services (AWS)\*, AT&T M2X\*, Predix\* from GE, or SAP Cloud Platform\* IoT, different cloud-based IoT platforms for machine to machine communication.
 
 ## What it is
 
-Using an Intel® Edison board or Intel® IoT Gateway, this project lets you create a line following robot that:<br>
+Using a compatible Intel® IoT Platform, this project lets you create a line following robot that:<br>
 - continuously checks the line finder sensor.<br>
 - moves forward if on the line, using the stepper motors.<br>
 - tries to pivot to find the line if not on it, using the stepper motors.<br>
@@ -25,111 +23,41 @@ The line finder robot uses the two attached motors to attempt to follow a line, 
 
 Optionally, data can be stored using your own Microsoft Azure\*, IBM Bluemix\*, AT&T M2X\*, AWS\*, Predix\*, or SAP\* account.
 
+## First time setup  
+For all the samples in this repository, see the ![General Setup Instructions](./../../README.md#setup) for supported boards and libraries.
+
 ## Hardware requirements
+
+In addition to using a compatible platform listed in ![Hardware Compatibility](./../../README.md#hardware-compatibility), here is additional hardware you will need to run this example.
 
 Grove\* Robotics Kit containing:
 
-1. Intel® Edison board with an Arduino\* breakout board or Intel® IoT Gateway with Arduino 101\* (branded Genuino 101\* outside the U.S.) board
+1. [Grove\* Base Shield V2](https://www.seeedstudio.com/Base-Shield-V2-p-1378.html)
 2. [Grove Line Finder](http://iotdk.Intel®.com/docs/master/upm/node/classes/grovelinefinder.html)
 3. [Stepper Motor Controller & Stepper Motor](http://iotdk.Intel®.com/docs/master/upm/node/classes/uln200xa.html) (x2)
 
 ## Software requirements
 
-1. Intel® XDK IoT Edition
+1. Node.js 
+2. MRAA and UPM Node.js bindings <link to mraa and upm install docs>
+2. Packages as listed in the package.json file in this example 
 2. Microsoft Azure\*, IBM Bluemix\*, AT&T M2X\*, AWS\*, Predix\*, or SAP\* account (optional)
-
-### How to set up
-
-To begin, clone the **How-To Code Samples** repository with Git\* on your computer as follows:
-
-    $ git clone https://github.com/Intel®-iot-devkit/how-to-code-samples.git
-
-Want to download a .zip file? In your web browser, go to <a href="https://github.com/Intel®-iot-devkit/how-to-code-samples">https://github.com/Intel®-iot-devkit/how-to-code-samples</a> and click the **Download ZIP** button at the lower right. Once the .zip file is downloaded, uncompress it, and then use the files in the directory for this example.
-
-## Adding the program to Intel® XDK IoT Edition
-
-In Intel® XDK IoT Edition, select **Import Your Node.js Project**:
-
-![](./../../images/js/xdk-menu.png)
-
-On the **New Project** screen, click on the folder icon:
-
-![](./../../images/js/xdk-new-project.png)
-
-Navigate to the directory where the example project exists and select it:
-
-![](./../../images/js/xdk-select.png)
-
-Choose a name for the project and click on the **Create** button. Then click on the **Continue** button to finish creating your project:
-
-![](./../../images/js/xdk-new-project-name.png)
-
-You need to connect to your Intel® Edison board from your computer to send code to it.
-
-![](./../../images/js/xdk-select-device.png)
-
-Click the **IoT Device** menu at the bottom left. If your Intel® Edison board is automatically recognized, select it.
-
-![](./../../images/js/xdk-manual-connect.png)
-
-Otherwise, select **Add Manual Connection**.
-In the **Address** field, type `192.168.2.15`.
-In the **Port** field, type `58888`.
-Click **Connect** to save your connection.
-
-### Installing the program manually on the Intel® Edison board
-
-Alternatively, you can set up the code manually on the Intel® Edison board.
-
-Clone the **How-To Code Samples** repository to your Intel® Edison board after you establish an SSH connection to it, as follows:
-
-    $ git clone https://github.com/Intel®-iot-devkit/how-to-code-samples.git
-
-Then, navigate to the directory with this example.
-
-To install Git\* on the Intel® Edison board (if you don’t have it yet), establish an SSH connection to the board and run the following command:
-
-    $ opkg install git
 
 ### Connecting the Grove\* sensors
 
-![](./../../images/js/line-follower.jpg)
+![](./../images/line-follower-grove.JPG)
 
 You need to have a Grove\* Shield connected to an Arduino\* compatible breakout board to plug all the Grove devices into the Grove Shield. Make sure you have the tiny VCC switch on the Grove Shield set to **5V**.
 
-You need to power the Intel® Edison board with the external power adapter that comes with your starter kit, or substitute it with an external 12V 1.5A power supply. You can also use an external battery, such as a 5V USB battery.
+You need to power the Intel® IoT Platform with the external power adapter that comes with your starter kit, or substitute it with an external 12V 1.5A power supply. You can also use an external battery, such as a 5V USB battery.
 
-In addition, you need a breadboard and an extra 5V power supply to provide power to both motors. Note: you need a separate battery or power supply for the motors. You cannot use the same power supply for both the Intel® Edison board and the motors, so you need either 2 batteries or 2 power supplies in total.
+In addition, you need a breadboard and an extra 5V power supply to provide power to both motors. Note: you need a separate battery or power supply for the motors. You cannot use the same power supply for both the Intel® IoT Platform and the motors, so you need either 2 batteries or 2 power supplies in total.
 
 1. Plug each of the stepper motor controllers into four pins on the Arduino\* breakout board for it to be able to be controlled. Connect stepper motor controller #1 to pins 4, 5, 6, and 7. Connect stepper motor controller #2 to pins 9, 10, 11, and 12. Connect both controllers to ground (GND), to the 5V power coming from the Arduino\* breakout board (VCC), and to the separate 5V power for the motors (VM).
 
 2. Plug one end of a Grove\* cable into the Grove\* Line Finder, and connect the other end to the D2 port on the Grove\* Shield.
 
-### Manual Intel® Edison board setup
-
-If you're running this code on your Intel® Edison board manually, you need to install some dependencies.
-
-To obtain the Node.js\* modules needed for this example to execute on the Intel® Edison board, run the following command:
-
-```
-npm install
-```
-
-### Intel® IoT Gateway setup
-
-You can run this example using an Intel® IoT Gateway connected to an Arduino 101\* (branded Genuino 101\* outside the U.S.) board.
-
-Make sure your Intel® IoT Gateway is setup using Intel® IoT Gateway Software Suite, by following the directions on the web site here:
-
-https://software.intel.com/en-us/getting-started-with-intel-iot-gateways-and-iotdk
-
-You must install the Intel® XDK on the Intel® IoT Gateway, by following the directions on the above link, under the section "Connecting to the Intel® XDK".
-
-The Arduino 101\* (branded Genuino 101\* outside the U.S.) board needs to have the Firmata\* firmware installed. If you have IMRAA installed on your gateway, this will be done automatically. Otherwise, install the StandardFirmata or ConfigurableFirmata sketch manually onto your Arduino 101\* (branded Genuino 101\* outside the U.S.) board.
-
-You will also need to configure the `config.json` in the example to use the Arduino 101\* (branded Genuino 101\* outside the U.S.) board. See the section "Configuring the example" below.
-
-### IoT cloud setup
+### IoT cloud setup (optional)
 
 You can optionally store the data generated by this sample program using cloud-based IoT platforms from Microsoft Azure\*, IBM Bluemix\*, AT&T M2X\*, AWS\*, Predix\*, or SAP\*.
 
@@ -137,7 +65,7 @@ For information on how to connect to your own cloud server, go to:
 
 [https://github.com/intel-iot-devkit/iot-samples-cloud-setup](https://github.com/intel-iot-devkit/iot-samples-cloud-setup)
 
-### MQTT server setup
+### MQTT server setup (optional)
 
 You can also optionally store the data generated by this sample program using MQTT, a machine-to-machine messaging server. You can use MQTT to connect to Microsoft Azure\*, IBM Bluemix\*, AT&T M2X\*, or AWS\*.
 
@@ -147,7 +75,7 @@ For information on how to connect to your own cloud MQTT messaging server, go to
 
 ## Configuring the example
 
-To configure the example for the Intel® Edison board, just leave the `platform` key in the `config.json` set to `edison`. To configure the example for the Intel® IoT Gateway, change the `platform` key in the `config.json` to `firmata` as follows:
+To configure the example for the Intel® IoT Platform, just leave the `platform` key in the `config.json` set to `edison`. To configure the example for the Intel® IoT Gateway, change the `platform` key in the `config.json` to `firmata` as follows:
 
 ```
 {
@@ -173,43 +101,15 @@ For information on how to configure the example for an optional Microsoft Azure\
 
 [https://github.com/intel-iot-devkit/iot-samples-cloud-setup](https://github.com/intel-iot-devkit/iot-samples-cloud-setup)
 
-## Running the program using Intel® XDK IoT Edition
+## Running the program 
 
-When you're ready to run the example, make sure you have saved all the files.
+To run this example on the board, simply enter
 
-![](./../../images/js/xdk-upload.png)
+    $ npm install
+    $ npm run
 
-Click the **Upload** icon to upload the files to the Intel® Edison board.
+### Determining your platform's IP Address
 
-![](./../../images/js/xdk-run.png)
-
-Click the **Run** icon at the bottom of Intel® XDK IoT Edition. This runs the code on the Intel® Edison board.
-
-![](./../../images/js/xdk-upload-run.png)
-
-If you made changes to the code, click **Upload and Run**. This runs the latest code with your changes on the Intel® Edison board.
-
-![](./../../images/js/line-following-output.png)
-
-You will see output similar to the above when the program is running.
-
-## Running the program manually
-
-To run the example manually on the Intel® Edison board, establish an SSH connection to the board and execute the following command:
-
-    node index.js
-
-### Determining the Intel® Edison board's IP address
-
-You can determine what IP address the Intel® Edison board is connected to by running the following command:
-
-    ip addr show | grep wlan
-
-You will see output similar to the following:
-
-    3: wlan0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast qlen 1000
-        inet 192.168.1.13/24 brd 192.168.1.255 scope global wlan0
-
-The IP address is shown next to `inet`. In the example above, the IP address is `192.168.1.13`.
+See the section on Finding Your Board's IP Address at the bottom of the ![Setup Instructions](./../../README.md#finding-your-boards-ip-address) readme. 
 
 IMPORTANT NOTICE: This software is sample software. It is not designed or intended for use in any medical, life-saving or life-sustaining systems, transportation systems, nuclear systems, or for any other mission-critical application in which the failure of the system could lead to critical injury or death. The software may not be fully tested and may contain bugs or errors; it may not be intended or suitable for commercial release. No regulatory approvals for the software have been obtained, and therefore software may not be certified for use in certain countries or environments.


### PR DESCRIPTION
In this example, the Edison is part of the Configuring the Example section, with instructions that hinge on the name. For example:  " just leave the `platform` key in the `config.json` set to `edison`. "